### PR TITLE
Do not dispose a system defined color platform resource

### DIFF
--- a/eclipse-rbe-plugin/src/com/essiembre/eclipse/rbe/ui/editor/i18n/tree/KeyTreeLabelProvider.java
+++ b/eclipse-rbe-plugin/src/com/essiembre/eclipse/rbe/ui/editor/i18n/tree/KeyTreeLabelProvider.java
@@ -104,7 +104,7 @@ public class KeyTreeLabelProvider
         groupFontKey.dispose();
         groupFontNoKey.dispose();
         keyFont.dispose();
-        colorCommented.dispose();
+//        colorCommented.dispose();
     }
 
     @Override


### PR DESCRIPTION
System Grey colour is being disposed by accident. This breaks other Eclipse UI plugins for obvious reasons.
This is a quick fix for the issue: do not dispose that specific colour.

I have noticed that you create and dispose colours manually. Feels like that has lead to this problem. See if perhaps you could use org.eclipse.jface.resource.ColorRegistry for caching colours. There is a similar class for Fonts as well.
