### PR TITLE
Added proper handling of tab characters in the output bundle (previously were encoded in Unicode).

### DIFF
--- a/eclipse-rbe-plugin/src/com/essiembre/eclipse/rbe/model/bundle/PropertiesGenerator.java
+++ b/eclipse-rbe-plugin/src/com/essiembre/eclipse/rbe/model/bundle/PropertiesGenerator.java
@@ -109,6 +109,10 @@ public final class PropertiesGenerator {
                     value = value.replaceAll("\r", "\\\\r");
                     value = value.replaceAll("\n", "\\\\n");
                 }
+
+                // handle tabs in value
+                value = value.replaceAll(
+                        "\t", "\\\\t"); //$NON-NLS-1$ //$NON-NLS-2$
             } else {
                 value = "";
             }


### PR DESCRIPTION
Added proper handling of tab characters in the output bundle (previously were encoded in Unicode).
Tab characters are currently encoded as '\u0009' in bundle. It seems reasonable to encode them as '\t' instead.
