### PR TITLE
Added "Copy Key" to context menu

### DIFF
--- a/eclipse-rbe-plugin/OSGI-INF/l10n/bundle.properties
+++ b/eclipse-rbe-plugin/OSGI-INF/l10n/bundle.properties
@@ -54,6 +54,7 @@ key.delete            = &Delete
 key.duplicate         = Du&plicate
 key.expandAll         = &Expand All
 key.filter.incomplete = Show only incomplete translations.
+key.getkey            = Copy Key
 key.layout.flat       = Flat
 key.layout.tree       = Tree
 key.new               = New

--- a/eclipse-rbe-plugin/OSGI-INF/l10n/bundle_es.properties
+++ b/eclipse-rbe-plugin/OSGI-INF/l10n/bundle_es.properties
@@ -54,6 +54,7 @@ key.delete            = &Borrar
 key.duplicate         = Du&plicar
 key.expandAll         = &Expandir todo
 key.filter.incomplete = Mostrar solo traducciones incompletas.
+key.getkey            = Copie la clave
 key.layout.flat       = Plano
 key.layout.tree       = \u00C1rbol
 key.new               = Nuevo

--- a/eclipse-rbe-plugin/OSGI-INF/l10n/bundle_zh.properties
+++ b/eclipse-rbe-plugin/OSGI-INF/l10n/bundle_zh.properties
@@ -54,6 +54,7 @@ key.delete            = \u5220\u9664(&D)
 key.duplicate         = \u590D\u5236(&P)
 key.expandAll         = \u5168\u90E8\u5C55\u5F00(&E)
 key.filter.incomplete = [Show only incomplete translations.]
+key.getkey            = \u590D\u5370\u952E
 key.layout.flat       = \u5E73\u9762
 key.layout.tree       = \u6811\u72B6
 key.new               = [New]

--- a/eclipse-rbe-plugin/OSGI-INF/l10n/bundle_zh_HK.properties
+++ b/eclipse-rbe-plugin/OSGI-INF/l10n/bundle_zh_HK.properties
@@ -54,6 +54,7 @@ key.delete            = \u522A\u9664(&D)
 key.duplicate         = \u8907\u88FD(&P)
 key.expandAll         = \u5168\u90E8\u5C55\u958B(&E)
 key.filter.incomplete = [Show only incomplete translations.]
+key.getkey            = \u590D\u5370\u952E
 key.layout.flat       = \u5E73\u9762
 key.layout.tree       = \u6A39\u72C0
 key.new               = [New]

--- a/eclipse-rbe-plugin/OSGI-INF/l10n/bundle_zh_TW.properties
+++ b/eclipse-rbe-plugin/OSGI-INF/l10n/bundle_zh_TW.properties
@@ -54,6 +54,7 @@ key.delete            = \u522A\u9664(&D)
 key.duplicate         = \u8907\u88FD(&P)
 key.expandAll         = \u5168\u90E8\u5C55\u958B(&E)
 key.filter.incomplete = [Show only incomplete translations.]
+key.getkey            = \u8907\u5370\u9375
 key.layout.flat       = \u5E73\u9762
 key.layout.tree       = \u6A39\u72C0
 key.new               = [New]


### PR DESCRIPTION
I needed a simplified way of copying the keys from the editor and created this **"Copy Key"** menu: it copies the key to the clipboard .

![image](https://cloud.githubusercontent.com/assets/547382/18211671/85fb6d18-7104-11e6-8ae8-7d219d7597f7.png)
