### PR TITLE
Show language banner image in the properties Editor

### DIFF
--- a/eclipse-rbe-plugin/src/com/essiembre/eclipse/rbe/ui/editor/i18n/BundleEntryComposite.java
+++ b/eclipse-rbe-plugin/src/com/essiembre/eclipse/rbe/ui/editor/i18n/BundleEntryComposite.java
@@ -682,7 +682,18 @@ public class BundleEntryComposite extends Composite {
             String imageName = "countries/" +
             countryCode.toLowerCase() + ".gif";
             image = UIUtils.getImage(imageName);
-        }
+            
+		} else if (countryLocale != null
+				&& countryLocale.getLanguage() != null
+				&& countryLocale.getLanguage().length() > 0) {
+
+			// show language image when country image is not available
+
+			String countryLanguage = countryLocale.getLanguage();
+			String imageName = "countries/" + countryLanguage.toLowerCase() + ".gif";
+
+			image = UIUtils.getImage(imageName);
+		}
         if (image == null) {
             image = UIUtils.getImage("countries/blank.gif");
         }


### PR DESCRIPTION
Currently when a country is not available in a properties file name, then the country banner is not displayed.

With this feature, the language in a locale is used to show the country banner.